### PR TITLE
🚀 CIのlint処理を高速化 - linter数を20個→10個に削減（CI用） - 詳細lintは開発用設定として分離（.golang…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,30 +16,65 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # 変更検出のため全履歴を取得
+
+    # Goファイルの変更を検出
+    - name: Check for Go file changes
+      id: go-changes
+      run: |
+        if [ "${{ github.event_name }}" = "push" ]; then
+          # pushの場合は前のコミットと比較
+          if git diff --name-only HEAD~1 HEAD | grep -E '\.(go|mod|sum)$' > /dev/null; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          # PRの場合はベースブランチと比較
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '\.(go|mod|sum)$' > /dev/null; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+        fi
 
     - name: Set up Go
+      if: steps.go-changes.outputs.changed == 'true'
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Cache Go modules
+    # 拡張されたキャッシュ戦略
+    - name: Cache Go modules and build cache
+      if: steps.go-changes.outputs.changed == 'true'
       uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          ~/.cache/golangci-lint
+        key: ${{ runner.os }}-go-lint-${{ hashFiles('**/go.sum', '.golangci.yml') }}
         restore-keys: |
+          ${{ runner.os }}-go-lint-
           ${{ runner.os }}-go-
 
     - name: Download dependencies
+      if: steps.go-changes.outputs.changed == 'true'
       run: go mod download
 
-    - name: Run golangci-lint (includes gosec security scan)
-      uses: golangci/golangci-lint-action@v3
+    # golangci-lintの高速化設定
+    - name: Run golangci-lint (optimized)
+      if: steps.go-changes.outputs.changed == 'true'
+      uses: golangci/golangci-lint-action@v6
       with:
-        version: latest
-        args: --timeout=10m --config=.golangci.yml
+        version: v1.61.0  # 固定バージョンでキャッシュ効果向上
+        args: --timeout=5m --config=.golangci.yml --fast
+        skip-cache: false
+
+    - name: Skip lint (no Go changes)
+      if: steps.go-changes.outputs.changed == 'false'
+      run: echo "No Go files changed, skipping lint"
 
   test:
     name: Test

--- a/.golangci-dev.yml
+++ b/.golangci-dev.yml
@@ -1,14 +1,9 @@
+# 開発時用の詳細lint設定（ローカル開発・PR前チェック用）
 run:
-  timeout: 5m
+  timeout: 10m
   issues-exit-code: 1
   tests: true
   modules-download-mode: readonly
-  skip-dirs:
-    - vendor
-    - .git
-  skip-files:
-    - ".*\\.pb\\.go$"
-    - ".*_generated\\.go$"
 
 output:
   formats:
@@ -20,7 +15,6 @@ output:
 
 linters-settings:
   govet:
-    # check-shadowing: true  # Deprecated - use enable: shadow instead
     enable:
       - shadow
     disable:
@@ -82,7 +76,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # 必須のエラー検出linter（高速）
+    # エラーを検出するlinter
     - errcheck
     - gosimple
     - govet
@@ -91,33 +85,33 @@ linters:
     - typecheck
     - unused
     
-    # 基本的なコードスタイルlinter（高速）
+    # コードスタイルlinter
     - gofmt
     - goimports
     - misspell
+    - revive
+    - whitespace
     
-    # セキュリティlinter（必要最小限）
+    # パフォーマンスlinter
+    - prealloc
+    
+    # セキュリティlinter
     - gosec
     
-    # 軽量なlinter
+    # その他の有用なlinter
     - unconvert
+    - unparam
     - asciicheck
+    - gochecknoinits
+    - gochecknoglobals
+    - goconst
+    - gocritic
+    - gocyclo
+    - mnd  # gomndの代わり
     - goprintffuncname
-    
-    # 重いlinterは無効化（開発時のみ使用）
-    # - revive      # 重い
-    # - whitespace  # 重い
-    # - prealloc    # 重い
-    # - unparam     # 重い
-    # - gochecknoinits  # 重い
-    # - gochecknoglobals # 重い
-    # - goconst     # 重い
-    # - gocritic    # 重い
-    # - gocyclo     # 重い
-    # - mnd         # 重い
-    # - nakedret    # 重い
-    # - nestif      # 重い
-    # - funlen      # 重い
+    - nakedret
+    - nestif
+    - funlen
 
 issues:
   uniq-by-line: true

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,26 @@ lint-install: ## golangci-lint をインストール
 	@echo "$(BLUE)Installing golangci-lint...$(NC)"
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-lint: ## リンターを実行 (CIと同じ設定)
-	@echo "$(BLUE)Running linter with .golangci.yml config...$(NC)"
+lint: lint-fast ## 高速リンター（CI用）を実行
+
+lint-fast: ## 高速リンター（CI用）を実行
+	@echo "$(BLUE)Running fast linter (CI config)...$(NC)"
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --config=.golangci.yml --timeout=10m; \
+		golangci-lint run --config=.golangci.yml --timeout=5m --fast; \
 	else \
 		echo "$(YELLOW)golangci-lint not found. Installing...$(NC)"; \
 		make lint-install; \
-		golangci-lint run --config=.golangci.yml --timeout=10m; \
+		golangci-lint run --config=.golangci.yml --timeout=5m --fast; \
+	fi
+
+lint-full: ## 詳細リンター（開発用）を実行
+	@echo "$(BLUE)Running full linter (development config)...$(NC)"
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run --config=.golangci-dev.yml --timeout=10m; \
+	else \
+		echo "$(YELLOW)golangci-lint not found. Installing...$(NC)"; \
+		make lint-install; \
+		golangci-lint run --config=.golangci-dev.yml --timeout=10m; \
 	fi
 
 install: ## バイナリをシステムにインストール


### PR DESCRIPTION
…ci-dev.yml） - キャッシュ戦略を最適化（golangci-lintキャッシュ追加） - 条件付き実行でGoファイル未変更時はスキップ - タイムアウトを10分→5分に短縮 - Makefileにlint-fast/lint-fullコマンド追加 期待効果：lint時間60-70%短縮（3-5分→1-2分）

## Overview

<!-- Brief description of what this PR does -->

## Background

<!-- Context and reasoning behind these changes -->

## Key Points

<!-- Highlight important aspects of this PR -->
- 
- 
- 

