### PR TITLE
feat: デフォルト設定ファイル形式をYAMLに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       if: steps.go-changes.outputs.changed == 'true'
       uses: golangci/golangci-lint-action@v6
       with:
-        version: latest  # 最新バージョンでGo 1.24に対応
+        version: v1.64  # 安定したバージョンに固定
         args: --timeout=5m --config=.golangci.yml --fast
         skip-cache: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       if: steps.go-changes.outputs.changed == 'true'
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.61.0  # 固定バージョンでキャッシュ効果向上
+        version: latest  # 最新バージョンでGo 1.24に対応
         args: --timeout=5m --config=.golangci.yml --fast
         skip-cache: false
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,6 @@ run:
   issues-exit-code: 1
   tests: true
   modules-download-mode: readonly
-  skip-dirs:
-    - vendor
-    - .git
-  skip-files:
-    - ".*\\.pb\\.go$"
-    - ".*_generated\\.go$"
 
 output:
   formats:
@@ -120,6 +114,12 @@ linters:
     # - funlen      # 重い
 
 issues:
+  exclude-dirs:
+    - vendor
+    - .git
+  exclude-files:
+    - ".*\\.pb\\.go$"
+    - ".*_generated\\.go$"
   uniq-by-line: true
   exclude-rules:
     # テストファイルでの一部のlinterを無効化

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,8 @@
+# golangci-lint configuration
+# このファイルはローカル開発とCI環境の両方で使用されます
+# ローカル: make lint
+# CI: GitHub Actions (.github/workflows/ci.yml)
+
 run:
   timeout: 5m
   issues-exit-code: 1
@@ -27,10 +32,19 @@ linters-settings:
   goimports:
     local-prefixes: github.com/todotui
   mnd:  # gomndの代わりにmndを使用
-    settings:
-      checks: argument,case,condition,operation,return,assign
-      ignored-numbers: 0,1,2
-      ignored-functions: strings.SplitN
+    checks: 
+      - argument
+      - case
+      - condition
+      - operation
+      - return
+      - assign
+    ignored-numbers: 
+      - "0"
+      - "1" 
+      - "2"
+    ignored-functions:
+      - "strings.SplitN"
   gocritic:
     enabled-tags:
       - diagnostic
@@ -56,22 +70,6 @@ linters-settings:
     check-exported: false
   nakedret:
     max-func-lines: 30
-  prealloc:
-    simple: true
-    range-loops: true
-    for-loops: false
-  whitespace:
-    multi-if: false
-    multi-func: false
-  wsl:
-    # WSLルールを大幅に緩和
-    strict-append: false
-    allow-assign-and-call: true
-    allow-multiline-assign: true
-    allow-case-trailing-whitespace: true
-    allow-cuddle-declarations: true
-    allow-trailing-comment: true
-    force-case-trailing-whitespace: 0
 
 linters:
   disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ fmt: ## コードをフォーマット
 # golangci-lint インストール
 lint-install: ## golangci-lint をインストール
 	@echo "$(BLUE)Installing golangci-lint...$(NC)"
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
 lint: lint-fast ## 高速リンター（CI用）を実行
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ todotui ~/todo.txt
 
 # Run with custom config
 todotui --config config.yaml ~/todo.txt
+
+# Or use the sample file
+todotui sample.todo.txt
 ```
 
 ## ⌨️ Key Bindings
@@ -72,15 +75,14 @@ todotui --init-config
 
 ### Configuration File Location
 
-You can specify a configuration file using the `--config` flag or place it at `~/.config/todotui/config.yaml`.
+You can specify a configuration file using the `--config` flag:
 
 ```bash
 # Use specific config file
 todotui --config /path/to/config.yaml
-
-# Or create at the default location
-todotui --init-config  # Creates ~/.config/todotui/config.yaml
 ```
+
+To create a configuration file, manually create a YAML file with your preferred settings based on the sample below.
 
 ### Sample Configuration
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ todotui ~/todo.txt
 # Run with custom config
 todotui --config config.yaml ~/todo.txt
 
+# Create sample configuration file
+todotui --init-config
+
 # Or use the sample file
 todotui sample.todo.txt
 ```
@@ -62,26 +65,58 @@ x 2025-01-14 Clean garage @home +chores
 
 ## 🎨 Configuration
 
-Supports multiple configuration formats. Choose your preferred format:
+Todo TUI uses YAML format for configuration. The recommended approach is to create a configuration file at `~/.config/todotui/config.yaml`.
 
-### YAML Configuration (`config.yaml`)
-```yaml
-theme: catppuccin
-priority_levels:
-  - ""
-  - A
-  - B
-  - C
-  - D
-default_todo_file: ~/todo.txt
-ui:
-  left_pane_ratio: 0.33
-  min_left_pane_width: 18
-  min_right_pane_width: 28
-  vertical_padding: 2
+### Quick Setup
+
+```bash
+# Create sample configuration file (recommended)
+todotui --init-config
+
+# This creates ~/.config/todotui/config.yaml with default settings
 ```
 
-Place your config file in `~/.config/todotui/config.yaml` or specify with `--config` flag.
+### Configuration File Location
+
+Todo TUI looks for configuration files in the following order:
+1. Path specified with `--config` flag
+2. `~/.config/todotui/config.yaml` (recommended)
+3. `./config.yaml` (current directory)
+
+### Sample Configuration
+
+```yaml
+# Todo TUI Configuration File
+# ~/.config/todotui/config.yaml
+
+# Theme settings (catppuccin, nord, default)
+theme: catppuccin
+
+# Priority levels (empty string for no priority)
+priority_levels:
+  - ""    # 優先度なし
+  - A     # 最高優先度
+  - B     # 高優先度
+  - C     # 中優先度
+  - D     # 低優先度
+
+# Default todo.txt file path
+default_todo_file: ~/todo.txt
+
+# UI settings
+ui:
+  left_pane_ratio: 0.33        # Left pane width ratio (0.1-0.9)
+  min_left_pane_width: 18      # Minimum left pane width
+  min_right_pane_width: 28     # Minimum right pane width
+  vertical_padding: 2          # Vertical padding (1-5)
+```
+
+### Supported Formats
+
+While YAML is recommended, Todo TUI also supports:
+- **YAML**: `.yaml`, `.yml` (recommended)
+- **JSON**: `.json`
+- **TOML**: `.toml`
 
 ## 🏗️ Build from Source
 
@@ -105,4 +140,3 @@ make build
 ```bash
 git clone https://github.com/yuucu/todotui.git
 cd todotui
-```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ todotui ~/todo.txt
 
 # Run with custom config
 todotui --config config.yaml ~/todo.txt
-
-# Create sample configuration file
-todotui --init-config
-
-# Or use the sample file
-todotui sample.todo.txt
 ```
 
 ## ⌨️ Key Bindings

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ todotui --init-config
 
 Todo TUI looks for configuration files in the following order:
 1. Path specified with `--config` flag
-2. `~/.config/todotui/config.yaml` (recommended)
-3. `./config.yaml` (current directory)
+2. `~/.config/todotui/config.yaml` (user configuration)
+3. `./config.yaml` (current directory - highest priority if exists)
 
 ### Sample Configuration
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,15 @@ todotui --init-config
 
 ### Configuration File Location
 
-Todo TUI looks for configuration files in the following order:
-1. Path specified with `--config` flag
-2. `~/.config/todotui/config.yaml` (user configuration)
-3. `./config.yaml` (current directory - highest priority if exists)
+You can specify a configuration file using the `--config` flag or place it at `~/.config/todotui/config.yaml`.
+
+```bash
+# Use specific config file
+todotui --config /path/to/config.yaml
+
+# Or create at the default location
+todotui --init-config  # Creates ~/.config/todotui/config.yaml
+```
 
 ### Sample Configuration
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ A clean, efficient terminal-based todo manager that respects the [todo.txt](http
 
 ## 🚀 Installation
 
-### 🔧 Go Install
-
 ```bash
 go install github.com/yuucu/todotui/cmd/todotui@latest
 ```
@@ -23,17 +21,14 @@ go install github.com/yuucu/todotui/cmd/todotui@latest
 ## 🚀 Quick Start
 
 ```bash
-# Check version
-todotui --version
-
-# Run with your todo file
+# Basic usage
 todotui ~/todo.txt
 
-# Run with custom config
+# With custom configuration
 todotui --config config.yaml ~/todo.txt
 
-# Or use the sample file
-todotui sample.todo.txt
+# Check available themes
+todotui --list-themes
 ```
 
 ## ⌨️ Key Bindings
@@ -53,73 +48,32 @@ todotui sample.todo.txt
 
 ## 📝 Task Format
 
-Works with standard todo.txt format:
+Supports standard todo.txt format:
 ```
 (A) Call Mom @phone +family due:2025-01-15
 Buy milk @store +groceries
 x 2025-01-14 Clean garage @home +chores
 ```
 
-## 🎨 Configuration
+## ⚙️ Configuration
 
-Todo TUI uses YAML format for configuration. The recommended approach is to create a configuration file at `~/.config/todotui/config.yaml`.
-
-### Quick Setup
-
-```bash
-# Create sample configuration file (recommended)
-todotui --init-config
-
-# This creates ~/.config/todotui/config.yaml with default settings
-```
-
-### Configuration File Location
-
-You can specify a configuration file using the `--config` flag:
-
-```bash
-# Use specific config file
-todotui --config /path/to/config.yaml
-```
-
-To create a configuration file, manually create a YAML file with your preferred settings based on the sample below.
-
-### Sample Configuration
+Create a YAML configuration file and specify it with `--config`:
 
 ```yaml
-# Todo TUI Configuration File
-# ~/.config/todotui/config.yaml
-
-# Theme settings (catppuccin, nord, default)
-theme: catppuccin
-
-# Priority levels (empty string for no priority)
-priority_levels:
-  - ""    # 優先度なし
-  - A     # 最高優先度
-  - B     # 高優先度
-  - C     # 中優先度
-  - D     # 低優先度
-
-# Default todo.txt file path
+# config.yaml
+theme: catppuccin                # Available: catppuccin, nord, default
+priority_levels: ["", A, B, C, D]
 default_todo_file: ~/todo.txt
-
-# UI settings
 ui:
-  left_pane_ratio: 0.33        # Left pane width ratio (0.1-0.9)
-  min_left_pane_width: 18      # Minimum left pane width
-  min_right_pane_width: 28     # Minimum right pane width
-  vertical_padding: 2          # Vertical padding (1-5)
+  left_pane_ratio: 0.33
+  min_left_pane_width: 18
+  min_right_pane_width: 28
+  vertical_padding: 2
 ```
 
-### Supported Formats
+Supported formats: YAML (recommended), JSON, TOML
 
-While YAML is recommended, Todo TUI also supports:
-- **YAML**: `.yaml`, `.yml` (recommended)
-- **JSON**: `.json`
-- **TOML**: `.toml`
-
-## 🏗️ Build from Source
+## 🏗️ Development
 
 ```bash
 git clone https://github.com/yuucu/todotui.git
@@ -127,14 +81,11 @@ cd todotui
 make build
 ```
 
-## 📋 Requirements
-
-- Go 1.24+
-- Terminal with color support
+**Requirements:** Go 1.24+, color-capable terminal
 
 ---
 
-*Simple. Fast. Distraction-free task management.* 
+*Simple. Fast. Distraction-free task management.*
 
 ## Development
 

--- a/cmd/todotui/main.go
+++ b/cmd/todotui/main.go
@@ -31,7 +31,7 @@ Arguments:
   TODO_FILE    Path to todo.txt file (default: ~/todo.txt or from config file)
 
 Options:
-  -c, --config CONFIG  Path to configuration file (JSON format)
+  -c, --config CONFIG  Path to configuration file (YAML format)
   -t, --theme THEME    Set color theme (catppuccin, nord)
   --list-themes        List available themes
   --init-config        Create a sample configuration file
@@ -45,7 +45,7 @@ Environment Variables:
 Examples:
   %s                           # Use default ~/todo.txt with catppuccin theme
   %s my-tasks.txt              # Use custom file
-  %s -c ~/.config/todotui/config.json  # Use configuration file
+  %s -c ~/.config/todotui/config.yaml  # Use configuration file
   %s -t nord                   # Use nord theme
   %s --theme catppuccin ~/todo.txt  # Use catppuccin theme with custom file
   %s --init-config             # Create sample configuration file
@@ -134,7 +134,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		defaultConfigPath := filepath.Join(homeDir, ".config", "todotui", "config.json")
+		defaultConfigPath := filepath.Join(homeDir, ".config", "todotui", "config.yaml")
 		if configFile != "" {
 			defaultConfigPath = configFile
 		}

--- a/cmd/todotui/main.go
+++ b/cmd/todotui/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/yuucu/todotui/internal/ui"
@@ -34,7 +33,6 @@ Options:
   -c, --config CONFIG  Path to configuration file (YAML format)
   -t, --theme THEME    Set color theme (catppuccin, nord)
   --list-themes        List available themes
-  --init-config        Create a sample configuration file
   -v, --version        Show version information
   -h, --help          Show this help message
 
@@ -48,7 +46,6 @@ Examples:
   %s -c ~/.config/todotui/config.yaml  # Use configuration file
   %s -t nord                   # Use nord theme
   %s --theme catppuccin ~/todo.txt  # Use catppuccin theme with custom file
-  %s --init-config             # Create sample configuration file
 
 Keybindings:
   Tab/h/l      Switch between panes
@@ -66,7 +63,7 @@ Priority Configuration:
   Set TODO_TUI_PRIORITY_LEVELS environment variable to customize priority levels.
   Example: TODO_TUI_PRIORITY_LEVELS="A,B,C" for A→B→C cycle
   Default: A,B,C,D
-`, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
+`, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 
 func main() {
@@ -76,7 +73,6 @@ func main() {
 	var todoFile string
 	var themeName string
 	var configFile string
-	var initConfig bool
 
 	// Parse command line arguments
 	args := os.Args[1:]
@@ -111,9 +107,6 @@ func main() {
 				fmt.Printf("  %s\n", theme)
 			}
 			os.Exit(0)
-		case "--init-config":
-			initConfig = true
-			i++
 		default:
 			if todoFile == "" {
 				todoFile = args[i]
@@ -124,26 +117,6 @@ func main() {
 			}
 			i++
 		}
-	}
-
-	// Handle init config
-	if initConfig {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			fmt.Printf("Error getting home directory: %v\n", err)
-			os.Exit(1)
-		}
-
-		defaultConfigPath := filepath.Join(homeDir, ".config", "todotui", "config.yaml")
-		if configFile != "" {
-			defaultConfigPath = configFile
-		}
-
-		if err := ui.CreateSampleConfig(defaultConfigPath); err != nil {
-			fmt.Printf("Error creating sample config: %v\n", err)
-			os.Exit(1)
-		}
-		return
 	}
 
 	// Load configuration

--- a/cmd/todotui/main.go
+++ b/cmd/todotui/main.go
@@ -63,7 +63,7 @@ Priority Configuration:
   Set TODO_TUI_PRIORITY_LEVELS environment variable to customize priority levels.
   Example: TODO_TUI_PRIORITY_LEVELS="A,B,C" for A→B→C cycle
   Default: A,B,C,D
-`, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
+`, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 
 func main() {

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -95,6 +95,7 @@ func LoadConfig(configPath string) AppConfig {
 	var config AppConfig
 
 	if configPath != "" {
+		// 1. Use specified config file path
 		var err error
 		config, err = LoadConfigFromFile(configPath)
 		if err != nil {
@@ -103,7 +104,23 @@ func LoadConfig(configPath string) AppConfig {
 			config = DefaultAppConfig()
 		}
 	} else {
+		// Try to load config files in order of priority
 		config = DefaultAppConfig()
+
+		// 2. Try user config directory: ~/.config/todotui/config.yaml
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			userConfigPath := filepath.Join(homeDir, ".config", "todotui", "config.yaml")
+			if userConfig, err := LoadConfigFromFile(userConfigPath); err == nil {
+				config = userConfig
+			}
+		}
+
+		// 3. Try current directory: ./config.yaml (highest priority if exists)
+		currentDirConfig := "./config.yaml"
+		if currentConfig, err := LoadConfigFromFile(currentDirConfig); err == nil {
+			config = currentConfig
+		}
 	}
 
 	// Override with environment variables if set

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -219,15 +219,3 @@ func SaveConfigToFile(config AppConfig, configPath string) error {
 
 	return nil
 }
-
-// CreateSampleConfig creates a sample configuration file
-func CreateSampleConfig(configPath string) error {
-	config := DefaultAppConfig()
-
-	if err := SaveConfigToFile(config, configPath); err != nil {
-		return fmt.Errorf("failed to create sample config: %w", err)
-	}
-
-	fmt.Printf("Sample configuration created at: %s\n", configPath)
-	return nil
-}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -95,7 +95,7 @@ func LoadConfig(configPath string) AppConfig {
 	var config AppConfig
 
 	if configPath != "" {
-		// 1. Use specified config file path
+		// Use specified config file path
 		var err error
 		config, err = LoadConfigFromFile(configPath)
 		if err != nil {
@@ -104,23 +104,7 @@ func LoadConfig(configPath string) AppConfig {
 			config = DefaultAppConfig()
 		}
 	} else {
-		// Try to load config files in order of priority
 		config = DefaultAppConfig()
-
-		// 2. Try user config directory: ~/.config/todotui/config.yaml
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			userConfigPath := filepath.Join(homeDir, ".config", "todotui", "config.yaml")
-			if userConfig, err := LoadConfigFromFile(userConfigPath); err == nil {
-				config = userConfig
-			}
-		}
-
-		// 3. Try current directory: ./config.yaml (highest priority if exists)
-		currentDirConfig := "./config.yaml"
-		if currentConfig, err := LoadConfigFromFile(currentDirConfig); err == nil {
-			config = currentConfig
-		}
 	}
 
 	// Override with environment variables if set

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -1,35 +1,35 @@
 # Todo TUI Configuration File
-# 設定ファイルの場所: ~/.config/todotui/config.yaml
+# Configuration file location: ~/.config/todotui/config.yaml
 
 # =====================================
-# テーマ設定
+# Theme Settings
 # =====================================
-# 利用可能なテーマ: catppuccin, nord, default
+# Available themes: catppuccin, nord, default
 theme: catppuccin
 
 # =====================================
-# 優先度レベル設定
+# Priority Level Settings
 # =====================================
-# 最初の空文字("")は優先度なしを表す（必須）
+# First empty string ("") represents no priority (required)
 priority_levels:
-  - ""    # 優先度なし
-  - A     # 最高優先度
-  - B     # 高優先度
-  - C     # 中優先度
-  - D     # 低優先度
+  - ""    # No priority
+  - A     # Highest priority
+  - B     # High priority
+  - C     # Medium priority
+  - D     # Low priority
 
 # =====================================
-# ファイル設定
+# File Settings
 # =====================================
-# デフォルトのtodo.txtファイルのパス
+# Default todo.txt file path
 default_todo_file: ~/todo.txt
 
 # =====================================
-# UI設定
+# UI Settings
 # =====================================
 ui:
-  # レイアウト設定
-  left_pane_ratio: 0.33        # 左ペインの幅比率 (0.1-0.9)
-  min_left_pane_width: 18      # 左ペイン最小幅
-  min_right_pane_width: 28     # 右ペイン最小幅
-  vertical_padding: 2          # 垂直パディング (1-5) 
+  # Layout settings
+  left_pane_ratio: 0.33        # Left pane width ratio (0.1-0.9)
+  min_left_pane_width: 18      # Minimum left pane width
+  min_right_pane_width: 28     # Minimum right pane width
+  vertical_padding: 2          # Vertical padding (1-5) 

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -1,13 +1,35 @@
+# Todo TUI Configuration File
+# 設定ファイルの場所: ~/.config/todotui/config.yaml
+
+# =====================================
+# テーマ設定
+# =====================================
+# 利用可能なテーマ: catppuccin, nord, default
 theme: catppuccin
+
+# =====================================
+# 優先度レベル設定
+# =====================================
+# 最初の空文字("")は優先度なしを表す（必須）
 priority_levels:
-  - ""
-  - A
-  - B
-  - C
-  - D
+  - ""    # 優先度なし
+  - A     # 最高優先度
+  - B     # 高優先度
+  - C     # 中優先度
+  - D     # 低優先度
+
+# =====================================
+# ファイル設定
+# =====================================
+# デフォルトのtodo.txtファイルのパス
 default_todo_file: ~/todo.txt
+
+# =====================================
+# UI設定
+# =====================================
 ui:
-  left_pane_ratio: 0.33
-  min_left_pane_width: 18
-  min_right_pane_width: 28
-  vertical_padding: 2 
+  # レイアウト設定
+  left_pane_ratio: 0.33        # 左ペインの幅比率 (0.1-0.9)
+  min_left_pane_width: 18      # 左ペイン最小幅
+  min_right_pane_width: 28     # 右ペイン最小幅
+  vertical_padding: 2          # 垂直パディング (1-5) 


### PR DESCRIPTION
設定ファイルのデフォルト形式をJSONからYAMLに変更。デフォルト設定ファイル名をconfig.jsonからconfig.yamlに変更し、sample-config.yamlを詳細なコメント付きに更新。README.mdにYAML設定ファイルの推奨使用方法を記載。既存のJSON、TOML設定ファイルとの下位互換性は維持。