### PR TITLE
docs: Add help keybinding (?) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ todotui --list-themes
 | `p` | Cycle priority (A→B→C→D→none) |
 | `r` | Restore deleted/completed task |
 | `y` | Copy task text to clipboard |
+| `?` | Show help |
 | `q` | Quit |
 
 ## 📝 Task Format


### PR DESCRIPTION
Add help keybinding documentation to README.md Key Bindings table. This improves discoverability of the help functionality for users.