### PR TITLE
feat: add automatic config file loading from ~/.config/todotui/config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ x 2025-01-14 Clean garage @home +chores
 
 ## ⚙️ Configuration
 
-Create a YAML configuration file and specify it with `--config`:
+Create a YAML configuration file at `~/.config/todotui/config.yaml`. todotui will automatically load this file if it exists.
+
+You can also specify a custom config file with `--config`:
 
 ```yaml
-# config.yaml
+# ~/.config/todotui/config.yaml
 theme: catppuccin                # Available: catppuccin, nord, default
 priority_levels: ["", A, B, C, D]
 default_todo_file: ~/todo.txt
@@ -67,6 +69,15 @@ ui:
   min_left_pane_width: 18
   min_right_pane_width: 28
   vertical_padding: 2
+```
+
+**Usage examples:**
+```bash
+# Automatic config detection (loads ~/.config/todotui/config.yaml)
+todotui ~/todo.txt
+
+# Use specific config file
+todotui --config /path/to/config.yaml ~/todo.txt
 ```
 
 Supported formats: YAML (recommended), JSON, TOML

--- a/cmd/todotui/main.go
+++ b/cmd/todotui/main.go
@@ -35,14 +35,13 @@ Options:
   -v, --version        Show version information
   -h, --help          Show this help message
 
-Environment Variables:
-  TODO_TUI_THEME         Set default theme (same as --theme)
-  TODO_TUI_PRIORITY_LEVELS  Set priority levels (example: "A,B,C")
+Configuration:
+  If no --config is specified, todotui will automatically load ~/.config/todotui/config.yaml if it exists.
 
 Examples:
-  %s                           # Use default ~/todo.txt with catppuccin theme
-  %s my-tasks.txt              # Use custom file
-  %s -c ~/.config/todotui/config.yaml  # Use configuration file
+  %s                           # Use default ~/todo.txt with automatic config detection
+  %s my-tasks.txt              # Use custom file with automatic config detection
+  %s -c ~/.config/todotui/config.yaml  # Use specific configuration file
   %s -t nord                   # Use nord theme
   %s --theme catppuccin ~/todo.txt  # Use catppuccin theme with custom file
 
@@ -57,11 +56,6 @@ Keybindings:
   p            Toggle task priority
   y            Copy task text to clipboard (right pane)
   q            Quit
-
-Priority Configuration:
-  Set TODO_TUI_PRIORITY_LEVELS environment variable to customize priority levels.
-  Example: TODO_TUI_PRIORITY_LEVELS="A,B,C" for A→B→C cycle
-  Default: A,B,C,D
 `, os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0], os.Args[0])
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -47,11 +46,6 @@ func NewModel(todoFile string, appConfig AppConfig) (*Model, error) {
 	taskList, err := todo.Load(todoFile)
 	if err != nil {
 		return nil, err
-	}
-
-	// Set theme from config
-	if appConfig.Theme != "" {
-		os.Setenv("TODO_TUI_THEME", appConfig.Theme)
 	}
 
 	model := &Model{


### PR DESCRIPTION
## 概要
設定ファイルの自動読み込み機能を追加しました。

## 変更内容
- `~/.config/todotui/config.yaml` からの自動設定ファイル読み込み機能を追加
- 環境変数による設定機能を削除（設定ファイル一本化）
- macOS固有の設定パスを削除（汎用性向上）
- 設定ファイル検索を単一パスに簡素化
- README.mdとヘルプメッセージを更新

## 使用方法
```bash
# ~/.config/todotui/config.yaml が存在する場合、自動的に読み込まれる
todotui ~/todo.txt

# 明示的に別の設定ファイルを指定することも可能
todotui --config /path/to/custom.yaml ~/todo.txt
```

## メリット
- XDG Base Directory Specificationに準拠
- 設定管理がシンプルになった
- アプリ固有のディレクトリで整理整頓
- 環境変数に依存しない明確な設定管理 