### PR TITLE
refactor: separate version code and support go install versioning

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -12,13 +12,6 @@ import (
 	"github.com/yuucu/todotui/pkg/ui"
 )
 
-// Build information variables (set by goreleaser)
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
-
 // config represents the parsed command line configuration
 type config struct {
 	configFile  string
@@ -42,12 +35,6 @@ func parseLogLevel(levelStr string) slog.Level {
 	default:
 		return slog.LevelWarn // デフォルトは警告レベル
 	}
-}
-
-func printVersion() {
-	fmt.Printf("todotui %s\n", version)
-	fmt.Printf("Commit: %s\n", commit)
-	fmt.Printf("Built: %s\n", date)
 }
 
 func printUsage() {
@@ -140,7 +127,7 @@ func runBubbleTea(cfg *config) error {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to initialize logger: %v\n", err)
 	}
 
-	logger.Info("todotui started", "version", version, "commit", commit)
+	logger.Info("todotui started", "version", GetVersion(), "commit", GetCommit())
 
 	// Determine todo file path
 	var finalTodoFile string
@@ -193,7 +180,7 @@ func Run() error {
 	}
 
 	if cfg.showVersion {
-		printVersion()
+		PrintVersion()
 		return nil
 	}
 

--- a/pkg/app/version.go
+++ b/pkg/app/version.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// Build information variables (set by goreleaser)
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// versionInfo holds version information from various sources
+type versionInfo struct {
+	version string
+	commit  string
+	date    string
+}
+
+// getVersionFromBuildInfo extracts version information from debug.ReadBuildInfo()
+func getVersionFromBuildInfo() *versionInfo {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	info := &versionInfo{
+		version: buildInfo.Main.Version,
+		commit:  "none",
+		date:    "unknown",
+	}
+
+	// Normalize version
+	if info.version == "(devel)" {
+		info.version = "dev"
+	}
+
+	// Extract VCS information
+	for _, setting := range buildInfo.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if len(setting.Value) >= 7 {
+				info.commit = setting.Value[:7] // short commit hash
+			} else {
+				info.commit = setting.Value
+			}
+		case "vcs.time":
+			info.date = setting.Value
+		}
+	}
+
+	return info
+}
+
+// getLDFlagsVersionInfo returns version info set via ldflags (for go build)
+func getLDFlagsVersionInfo() *versionInfo {
+	if version != "" && version != "dev" {
+		return &versionInfo{
+			version: version,
+			commit:  commit,
+			date:    date,
+		}
+	}
+	return nil
+}
+
+// getFallbackVersionInfo returns fallback version information
+func getFallbackVersionInfo() *versionInfo {
+	return &versionInfo{
+		version: version,
+		commit:  commit,
+		date:    date,
+	}
+}
+
+// PrintVersion prints version information to stdout
+func PrintVersion() {
+	var info *versionInfo
+
+	// Try version sources in priority order:
+	// 1. LDFLAGS (go build with custom flags)
+	// 2. Build info (go install)
+	// 3. Fallback (default values)
+	if info = getLDFlagsVersionInfo(); info != nil {
+		// go build with ldflags
+	} else if info = getVersionFromBuildInfo(); info != nil {
+		// go install or go build without ldflags
+	} else {
+		// fallback
+		info = getFallbackVersionInfo()
+	}
+
+	fmt.Printf("todotui %s\n", info.version)
+	fmt.Printf("Commit: %s\n", info.commit)
+	fmt.Printf("Built: %s\n", info.date)
+}
+
+// GetVersion returns the current version string for logging purposes
+func GetVersion() string {
+	if info := getLDFlagsVersionInfo(); info != nil {
+		return info.version
+	}
+	if info := getVersionFromBuildInfo(); info != nil {
+		return info.version
+	}
+	return version
+}
+
+// GetCommit returns the current commit hash for logging purposes
+func GetCommit() string {
+	if info := getLDFlagsVersionInfo(); info != nil {
+		return info.commit
+	}
+	if info := getVersionFromBuildInfo(); info != nil {
+		return info.commit
+	}
+	return commit
+}


### PR DESCRIPTION
## 概要

この PR では、バージョン情報の処理を改善し、`go install` でもバージョン情報が正しく表示されるようにしました。

## 変更内容

### 🔧 リファクタリング
- `pkg/app/app.go` からバージョン関連のコードを `pkg/app/version.go` に分離
- より保守しやすい構造に変更

### ✨ 新機能
- `debug.ReadBuildInfo()` を使用して `go install` でもバージョン情報を取得
- VCS（Git）情報からコミットハッシュとタイムスタンプを自動取得
- 複数のバージョン情報源の優先順位付け

### 📦 新しい公開関数
- `PrintVersion()`: バージョン情報を標準出力に表示
- `GetVersion()`: ログ用にバージョン文字列を取得
- `GetCommit()`: ログ用にコミットハッシュを取得

## 動作確認

### go install の場合
```bash
$ go install ./cmd/todotui
$ todotui -v
todotui v0.7.0+dirty
Commit: 8a4e803
Built: 2025-06-01T23:12:37Z
```

### make build の場合（従来のldflags）
```bash
$ make build
$ ./bin/todotui -v
todotui v0.7.0-dirty
Commit: 8a4e803
Built: 2025-06-01T23:12:46Z
```

## 参考

- [【Golang】"go install" でアプリのバージョン情報に自動対応させる【Go 1.16+】](https://qiita.com/KEINOS/items/cbc410ce3ee809cb9a20)
- Go 1.16+ の `debug.ReadBuildInfo()` を活用

## テスト

- ✅ 全てのテストが通過
- ✅ リンターエラーなし
- ✅ フォーマット済み 